### PR TITLE
Feature/pc npc구현및 pc의 스킬구성

### DIFF
--- a/PCNPC.c
+++ b/PCNPC.c
@@ -1,0 +1,768 @@
+#pragma warning(disable:4996)
+#include <stdio.h>
+#include <Windows.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <conio.h>
+#include <stdbool.h>
+//헤더 파일
+#include "DrawBoard.h"
+#include "Cursor.h"
+#include "Color.h"
+#include "Stage.h"
+#include "MainMenu.h"
+#include "ProcessKeyInput.h"
+#include "PCNPC.h"
+#include "Skill.h"
+int ChainsawTouched[6] = { 0 };
+int NpcInfo[maxmob][2] = { 0 };
+int RangeNpcInfo[maxmob][2] = { 0 };
+int StopRangeNpcInfo[maxmob][3] = { 0 };
+int PCPoint[2] = { 10,10 };
+int ProjectileInfo[maxProjectile][3] = { 0 };
+
+int TimeCount = 0;
+int AttackCount = 0;
+int item = 0; //드랍 아이템 번호
+int CHAINSAWindex;
+COORD pc; //pc 좌표
+
+COORD RandomSideXY() {
+    COORD side;
+    int ran;
+    while (1) {
+        ran = rand() % 4;
+
+        //npc 생성 좌표 지정
+        switch (ran)
+        {
+        default:
+            side.X = 1;
+            side.Y = 1;
+            break;
+        case 0: //왼변
+            side.X = 1;
+            side.Y = rand() % (GBOARD_HEIGHT - 1) + 1;
+            break;
+        case 1: //우변
+            side.X = GBOARD_WIDTH - 1;
+            side.Y = rand() % (GBOARD_HEIGHT - 1) + 1;
+            break;
+        case 2: //상변
+            side.X = rand() % (GBOARD_WIDTH - 1) + 1;
+            side.Y = 1;
+            break;
+        case 3: //하변
+            side.X = rand() % (GBOARD_WIDTH - 1) + 1;
+            side.Y = GBOARD_HEIGHT - 1;
+            break;
+        }
+
+        if (GameBoardInfo[side.Y][side.X] == 0) {
+            /*SetCurrentCursorPos(0, 0);
+            printf("%d, %d", side.X, side.Y);*/
+            return side;
+        }
+    }
+}
+
+void NpcSpawn()  //랜덤으로 npc 생성 (1~width-1),(1~height-1) 좌표에
+{
+    COORD side = RandomSideXY();
+
+    for (int i = 0; i < maxmob; i++) //npc최대 수만큼 차면 더 이상 생성 x
+    {
+        if (NpcInfo[i][0] != 0) continue;
+
+        NpcInfo[i][0] = side.X, NpcInfo[i][1] = side.Y;
+        GameBoardInfo[side.Y][side.X] = NPC;
+
+        SetCurrentCursorPos(NpcInfo[i][0] * 2 + GBOARD_ORIGIN_X, NpcInfo[i][1] + GBOARD_ORIGIN_Y);
+        drawNpcShape();
+        break;
+    }
+}
+
+void RangeNpcSpawn() // 원거리 npc 생성  테두리 쪽에서 랜덤 생성
+{
+    COORD side = RandomSideXY();
+
+    for (int i = 0; i < maxmob; i++) //npc최대 수만큼 차면 더 이상 생성 x
+    {
+        if (RangeNpcInfo[i][0] != 0 || StopRangeNpcInfo[i][0] != 0) continue;
+
+        RangeNpcInfo[i][0] = side.X, RangeNpcInfo[i][1] = side.Y;
+        GameBoardInfo[side.Y][side.X] = MOVINGRANGENPC;
+
+        SetCurrentCursorPos(RangeNpcInfo[i][0] * 2 + GBOARD_ORIGIN_X, RangeNpcInfo[i][1] + GBOARD_ORIGIN_Y);
+        drawRangeNpcShape();
+        break;
+    }
+}
+
+void NpcMove()   // NPC 이동
+{
+    int x, y;
+    int a = 0, b = 0;    //a,b 는 1과 0의 쌍  
+    int ran;
+    int PCPointX = 0;
+    int PCPointY = 0;
+
+    for (int i = 0; i < maxmob; i++)
+    {
+        if (NpcInfo[i][0] != 0)
+        {
+            PCPointX = PCPoint[0];
+            PCPointY = PCPoint[1];
+
+            x = NpcInfo[i][0], y = NpcInfo[i][1];  //npc가 이동할 위치 x,y
+            SetCurrentCursorPos(NpcInfo[i][0] * 2 + GBOARD_ORIGIN_X, NpcInfo[i][1] + GBOARD_ORIGIN_Y);
+            printf("  ");
+            GameBoardInfo[NpcInfo[i][1]][NpcInfo[i][0]] = 0;
+
+            if (PCPointX + 1 <= x)PCPointX++;
+            if (PCPointY + 1 <= y)PCPointY++;
+
+            if (PCPointX > NpcInfo[i][0])x++;
+            else if (PCPointX < NpcInfo[i][0])x--;
+            if (PCPointY > NpcInfo[i][1])y++;
+            else if (PCPointY < NpcInfo[i][1])y--;
+
+            if (GameBoardInfo[y][x] == PC)
+            {
+                NpcDie(NpcInfo[i][0], NpcInfo[i][1]);
+                // pc와 충돌 -> pc HP 마이너스 시키기
+                DecreaseHP();
+                continue;
+            } 
+            //npc, rangenpc, stoprangenpc, wall, life, bomb 충돌 시 랜덤의 방향으로 돌아가기
+            else if (GameBoardInfo[y][x] == NPC || GameBoardInfo[y][x] == MOVINGRANGENPC || GameBoardInfo[y][x] == STOPPEDRANGENPC || GameBoardInfo[y][x] == WALL || GameBoardInfo[y][x] == LIFE || GameBoardInfo[y][x] == BOMB || GameBoardInfo[y][x] == CHAINSAW)
+            {
+                ran = rand() % 4;
+                if (ran == 0) { a = 1; b = 0; }
+                else if (ran == 1) { a = 0; b = 1; }
+                else if (ran == 2) { a = -1; b = 0; }
+                else if (ran == 3) { a = 0; b = -1; }
+                x = NpcInfo[i][0] + a;
+                y = NpcInfo[i][1] + b;
+
+                //npc, rangenpc, stoprangenpc, wall, life, bomb 충돌
+                if (GameBoardInfo[y][x] == NPC || GameBoardInfo[y][x] == MOVINGRANGENPC || GameBoardInfo[y][x] == STOPPEDRANGENPC || GameBoardInfo[y][x] == WALL || GameBoardInfo[y][x] == LIFE || GameBoardInfo[y][x] == BOMB || GameBoardInfo[y][x] == CHAINSAW)
+                {
+                    x = NpcInfo[i][0] + b;
+                    y = NpcInfo[i][1] + a;
+                }
+                if (GameBoardInfo[y][x] == NPC || GameBoardInfo[y][x] == MOVINGRANGENPC || GameBoardInfo[y][x] == STOPPEDRANGENPC || GameBoardInfo[y][x] == WALL || GameBoardInfo[y][x] == LIFE || GameBoardInfo[y][x] == BOMB || GameBoardInfo[y][x] == CHAINSAW)
+                {
+                    x = NpcInfo[i][0] - a;
+                    y = NpcInfo[i][1] - b;
+                }
+                if (GameBoardInfo[y][x] == NPC || GameBoardInfo[y][x] == MOVINGRANGENPC || GameBoardInfo[y][x] == STOPPEDRANGENPC || GameBoardInfo[y][x] == WALL || GameBoardInfo[y][x] == LIFE || GameBoardInfo[y][x] == BOMB || GameBoardInfo[y][x] == CHAINSAW)
+                {
+                    x = NpcInfo[i][0] - b;
+                    y = NpcInfo[i][1] - a;           //원상복구  아무 방향에 갈 곳 없으면 가만히 있기 
+                }
+                if (GameBoardInfo[y][x] == NPC || GameBoardInfo[y][x] == MOVINGRANGENPC || GameBoardInfo[y][x] == STOPPEDRANGENPC || GameBoardInfo[y][x] == WALL || GameBoardInfo[y][x] == LIFE || GameBoardInfo[y][x] == BOMB || GameBoardInfo[y][x] == CHAINSAW)
+                {
+                    x = NpcInfo[i][0];
+                    y = NpcInfo[i][1];
+                }
+            }
+            else if (GameBoardInfo[y][x] > 100) {
+                //스킬 이펙트와 충돌
+                if (GameBoardInfo[y][x] < 300) {
+                    if (GameBoardInfo[y][x] < 400) {
+                        for (int i = 0; i <= skillTop; i++) {
+                            if (skillEffectInfo[i].X == x && skillEffectInfo[i].Y == y) {
+                                RemoveSkillEffect(i);
+                                break;
+                            }
+                        }
+                    }
+                    else {
+                        GameBoardInfo[y][x] = 0;
+                        SetCurrentCursorPos(GBOARD_ORIGIN_X + x * 2, GBOARD_ORIGIN_Y + y);
+                        printf("  ");
+                    }
+                }
+                NpcDie(NpcInfo[i][0], NpcInfo[i][1]);
+                continue;
+            }
+            NpcInfo[i][0] = x;
+            NpcInfo[i][1] = y;
+
+            GameBoardInfo[NpcInfo[i][1]][NpcInfo[i][0]] = NPC;
+            SetCurrentCursorPos(NpcInfo[i][0] * 2 + GBOARD_ORIGIN_X, NpcInfo[i][1] + GBOARD_ORIGIN_Y);
+            drawNpcShape();
+        }
+    }
+}
+
+void RangeNpcMove() //생성되고 한 턴후 부딪히는 거 처리  처음에 바로안멈춤
+{
+    int x, y;
+    int a = 0, b = 0;    //a,b 는 1과 0의 쌍
+    int ran;
+    int PCPointX = 0;
+    int PCPointY = 0;
+
+    for (int i = 0; i < maxmob; i++)
+    {
+        if (RangeNpcInfo[i][0] != 0)
+        {
+            PCPointX = PCPoint[0];
+            PCPointY = PCPoint[1];
+
+            x = RangeNpcInfo[i][0], y = RangeNpcInfo[i][1];
+            SetCurrentCursorPos(RangeNpcInfo[i][0] * 2 + GBOARD_ORIGIN_X, RangeNpcInfo[i][1] + GBOARD_ORIGIN_Y);
+            printf("  ");
+            GameBoardInfo[RangeNpcInfo[i][1]][RangeNpcInfo[i][0]] = 0;
+
+            if (PCPointX + 1 <= x)PCPointX++;
+            if (PCPointY + 1 <= y)PCPointY++;
+
+            if (PCPointX > RangeNpcInfo[i][0])x++;
+            else if (PCPointX < RangeNpcInfo[i][0])x--;
+            if (PCPointY > RangeNpcInfo[i][1])y++;
+            else if (PCPointY < RangeNpcInfo[i][1])y--;
+
+            if (GameBoardInfo[y][x] == PC)
+            {
+                //RangeNpcDie(RangeNpcInfo[i][0], RangeNpcInfo[i][1]);
+                DecreaseHP(); // pc와 충돌 -> pc HP 마이너스 시키기
+                continue;
+            }
+            else if (GameBoardInfo[y][x] == NPC || GameBoardInfo[y][x] == MOVINGRANGENPC || GameBoardInfo[y][x] == STOPPEDRANGENPC || GameBoardInfo[y][x] == WALL || GameBoardInfo[y][x] == LIFE || GameBoardInfo[y][x] == BOMB || GameBoardInfo[y][x] == CHAINSAW)  // npc 가는 위치 막혀있으면 다른 길로 가기    //랜덤으로 구현해놨지만 거리 재서 가장 가까운 곳으로 가기 안되면 가만히 있기
+            {
+                ran = rand() % 4;
+                if (ran == 0) { a = 1; b = 0; }
+                else if (ran == 1) { a = 0; b = 1; }
+                else if (ran == 2) { a = -1; b = 0; }
+                else if (ran == 3) { a = 0; b = -1; }
+                x = RangeNpcInfo[i][0] + a;
+                y = RangeNpcInfo[i][1] + b;
+                if (GameBoardInfo[y][x] == NPC || GameBoardInfo[y][x] == MOVINGRANGENPC || GameBoardInfo[y][x] == STOPPEDRANGENPC || GameBoardInfo[y][x] == WALL || GameBoardInfo[y][x] == LIFE || GameBoardInfo[y][x] == BOMB || GameBoardInfo[y][x] == CHAINSAW)
+                {
+                    x = RangeNpcInfo[i][0] + b;
+                    y = RangeNpcInfo[i][1] + a;
+                }
+                if (GameBoardInfo[y][x] == NPC || GameBoardInfo[y][x] == MOVINGRANGENPC || GameBoardInfo[y][x] == STOPPEDRANGENPC || GameBoardInfo[y][x] == WALL || GameBoardInfo[y][x] == LIFE || GameBoardInfo[y][x] == BOMB || GameBoardInfo[y][x] == CHAINSAW)
+                {
+                    x = RangeNpcInfo[i][0] - a;
+                    y = RangeNpcInfo[i][1] - b;
+                }
+                if (GameBoardInfo[y][x] == NPC || GameBoardInfo[y][x] == MOVINGRANGENPC || GameBoardInfo[y][x] == STOPPEDRANGENPC || GameBoardInfo[y][x] == WALL || GameBoardInfo[y][x] == LIFE || GameBoardInfo[y][x] == BOMB || GameBoardInfo[y][x] == CHAINSAW)
+                {
+                    x = RangeNpcInfo[i][0] - b;
+                    y = RangeNpcInfo[i][1] - a;
+                }
+                if (GameBoardInfo[y][x] == NPC || GameBoardInfo[y][x] == MOVINGRANGENPC || GameBoardInfo[y][x] == STOPPEDRANGENPC || GameBoardInfo[y][x] == WALL || GameBoardInfo[y][x] == LIFE || GameBoardInfo[y][x] == BOMB || GameBoardInfo[y][x] == CHAINSAW)
+                {
+
+                    x = RangeNpcInfo[i][0];
+                    y = RangeNpcInfo[i][1];           //원상복구
+                }
+            }
+            else if (GameBoardInfo[y][x] > 100) {
+                //스킬 이펙트와 충돌
+                if (GameBoardInfo[y][x] < 300) {
+                    if (GameBoardInfo[y][x] < 400) {
+                        for (int i = 0; i <= skillTop; i++) {
+                            if (skillEffectInfo[i].X == x && skillEffectInfo[i].Y == y) {
+                                RemoveSkillEffect(i);
+                                break;
+                            }
+                        }
+                    }
+                    else {
+                        GameBoardInfo[y][x] = 0;
+                        SetCurrentCursorPos(GBOARD_ORIGIN_X + x * 2, GBOARD_ORIGIN_Y + y);
+                        printf("  ");
+                    }
+                }
+                RangeNpcDie(RangeNpcInfo[i][0], RangeNpcInfo[i][1]);
+                continue;
+            }
+            RangeNpcInfo[i][0] = x;
+            RangeNpcInfo[i][1] = y;
+
+            GameBoardInfo[RangeNpcInfo[i][1]][RangeNpcInfo[i][0]] = MOVINGRANGENPC;
+            SetCurrentCursorPos(RangeNpcInfo[i][0] * 2 + GBOARD_ORIGIN_X, RangeNpcInfo[i][1] + GBOARD_ORIGIN_Y);
+            drawRangeNpcShape();
+
+            // 거리 10보다 작으면 멈춤 처리(stop 원거리 npc 배열에 추가) 
+            if (DistanceSquare(PCPoint[0], PCPoint[1], RangeNpcInfo[i][0], RangeNpcInfo[i][1]) < 10 * 10)
+            {
+                GameBoardInfo[RangeNpcInfo[i][1]][RangeNpcInfo[i][0]] = STOPPEDRANGENPC;
+                SetCurrentCursorPos(RangeNpcInfo[i][0] * 2 + GBOARD_ORIGIN_X, RangeNpcInfo[i][1] + GBOARD_ORIGIN_Y);
+                drawStopRangeNpcShape();
+                if (StopRangeNpcInfo[i][0] == 0)
+                {
+                    StopRangeNpcInfo[i][0] = RangeNpcInfo[i][0];
+                    StopRangeNpcInfo[i][1] = RangeNpcInfo[i][1];
+
+                    RangeNpcInfo[i][0] = 0;
+                    RangeNpcInfo[i][1] = 0;
+                    break;
+                }
+            }
+        }
+    }
+}
+
+void NpcDie(int Npc_X, int Npc_Y) // 그 자리에 npc 죽이고  npc인포 최신화
+{
+    int ran = rand();
+    if (Npc_X == 0 || Npc_X == GBOARD_WIDTH || Npc_Y == 0 || Npc_Y == GBOARD_HEIGHT) return;
+
+    //아이템 드랍
+    SetCurrentCursorPos(Npc_X * 2 + GBOARD_ORIGIN_X, Npc_Y + GBOARD_ORIGIN_Y);
+    if (ran % 100 < Diff.itemRate) {
+        //아이템 그리고 게임판에 추가
+        GameBoardInfo[Npc_Y][Npc_X] = DropItem();
+    }
+    else {
+        //칸 비우고 게임판에서 삭제
+        printf("  ");
+        GameBoardInfo[Npc_Y][Npc_X] = 0;
+    }
+
+    for (int i = 0; i < maxmob; i++)
+    {
+        if (NpcInfo[i][0] == Npc_X && NpcInfo[i][1] == Npc_Y)
+        {
+            NpcInfo[i][0] = 0;
+            break;
+        }
+    }
+}
+
+void RangeNpcDie(int Npc_X, int Npc_Y) // 위와 동일
+{
+    int ran = rand();
+    if (Npc_X == 0 || Npc_X == GBOARD_WIDTH || Npc_Y == 0 || Npc_Y == GBOARD_HEIGHT) return;
+
+    SetCurrentCursorPos(Npc_X * 2 + GBOARD_ORIGIN_X, Npc_Y + GBOARD_ORIGIN_Y);
+    
+    //아이템 드랍
+    if (ran % 100 < Diff.itemRate) {
+        //아이템 그리고 게임판에 추가
+        GameBoardInfo[Npc_Y][Npc_X] = DropItem();
+    }
+    else {
+        //칸 비우고 게임판에서 삭제
+        printf("  ");
+        GameBoardInfo[Npc_Y][Npc_X] = 0;
+    }
+
+    for (int i = 0; i < maxmob; i++)
+    {
+        if (RangeNpcInfo[i][0] == Npc_X && RangeNpcInfo[i][1] == Npc_Y)
+        {
+            RangeNpcInfo[i][0] = 0;
+            break;
+        }
+    }
+}
+
+void StopRangeNpcDie(int Npc_X, int Npc_Y) //위와 동일
+{
+    int ran = rand();
+    if (Npc_X == 0 || Npc_X == GBOARD_WIDTH || Npc_Y == 0 || Npc_Y == GBOARD_HEIGHT) return;
+
+    SetCurrentCursorPos(Npc_X * 2 + GBOARD_ORIGIN_X, Npc_Y + GBOARD_ORIGIN_Y);
+    
+    //아이템 드랍
+    if (ran % 100 < Diff.itemRate) {
+        //아이템 그리고 게임판에 추가
+        GameBoardInfo[Npc_Y][Npc_X] = DropItem();
+    }
+    else {
+        //칸 비우고 게임판에서 삭제
+        printf("  ");
+        GameBoardInfo[Npc_Y][Npc_X] = 0;
+    }
+
+    for (int i = 0; i < maxmob; i++)
+    {
+        if (StopRangeNpcInfo[i][0] == Npc_X && StopRangeNpcInfo[i][1] == Npc_Y)
+        {
+            StopRangeNpcInfo[i][0] = 0;
+            break;
+        }
+    }
+}
+
+int DistanceSquare(int x1, int y1, int x2, int y2)  //거리 계산
+{
+    return (x1 - x2) * (x1 - x2) + (y1 - y2) * (y1 - y2);
+}
+
+void RangeNpcAttack()  //원거리 npc 공격
+{
+    for (int i = 0; i < maxmob; i++)
+    {
+        if (StopRangeNpcInfo[i][0] == 0) continue;  //멈춘 원거리 npc 없으면 continue
+        
+        for (int j = 0; j < maxProjectile; j++)  //투사체 배열에 공간이 남아 있으면
+        {
+            if (ProjectileInfo[j][0] != 0) continue; //예외 처리
+
+            //공격 방향 업데이트
+            RangeNpcAttackDirectionUpdate();
+
+            //투사체 배열에 StopRangeNpc좌표 저장
+            ProjectileInfo[j][0] = StopRangeNpcInfo[i][0];
+            ProjectileInfo[j][1] = StopRangeNpcInfo[i][1];
+
+            //투사체 방향 저장하고 좌표 업데이트
+            switch (StopRangeNpcInfo[i][2])
+            {
+            default:
+                break;
+            case UP:
+                ProjectileInfo[j][2] = UP;
+                ProjectileInfo[j][1]--;
+                break;
+            case DOWN:
+                ProjectileInfo[j][2] = DOWN;
+                ProjectileInfo[j][1]++;
+                break;
+            case LEFT:
+                ProjectileInfo[j][2] = LEFT;
+                ProjectileInfo[j][0]--;
+                break;
+            case RIGHT:
+                ProjectileInfo[j][2] = RIGHT;
+                ProjectileInfo[j][0]++;
+                break;
+            }
+
+            //투사체 충돌 검사 및 추가 시도
+            if (GameBoardInfo[ProjectileInfo[j][1]][ProjectileInfo[j][0]] == 0 || GameBoardInfo[ProjectileInfo[j][1]][ProjectileInfo[j][0]] > 100) {
+                //비어있으면 npcbullet 저장하고 그리기
+                SetCurrentCursorPos(ProjectileInfo[j][0] * 2 + GBOARD_ORIGIN_X, ProjectileInfo[j][1] + GBOARD_ORIGIN_Y);
+                textcolor(darkRED);
+                switch (ProjectileInfo[j][2])
+                {
+                default:
+                    break;
+                case UP:
+                    printf("↑");
+                    break;
+                case DOWN:
+                    printf("↓");
+                    break;
+                case LEFT:
+                    printf("←");
+                    break;
+                case RIGHT:
+                    printf("→");
+                    break;
+                }
+
+                if (GameBoardInfo[ProjectileInfo[j][1]][ProjectileInfo[j][0]] > 100) {
+                    if (GameBoardInfo[ProjectileInfo[j][1]][ProjectileInfo[j][0]] < 300) {
+                        if (GameBoardInfo[ProjectileInfo[j][1]][ProjectileInfo[j][0]] < 400) {
+                            for (int k = 0; k <= skillTop; k++) {
+                                if (skillEffectInfo[k].X == ProjectileInfo[j][0] && skillEffectInfo[k].Y == ProjectileInfo[j][1]) {
+                                    RemoveSkillEffect(k);
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                    ProjectileExtinction(ProjectileInfo[j][0], ProjectileInfo[j][1]);
+                }
+                else GameBoardInfo[ProjectileInfo[j][1]][ProjectileInfo[j][0]] = NPCBULLET;
+            }
+            else if (GameBoardInfo[ProjectileInfo[j][1]][ProjectileInfo[j][0]] == LIFE || GameBoardInfo[ProjectileInfo[j][1]][ProjectileInfo[j][0]] == BOMB) {
+                //아이템일 경우 npcbullet 및 아이템 삭제
+                ProjectileExtinction(ProjectileInfo[j][0], ProjectileInfo[j][1]);
+            }
+            else if (GameBoardInfo[ProjectileInfo[j][1]][ProjectileInfo[j][0]] == PC) {
+                //pc일 경우 투사체 삭제하고 hp 감소
+                ProjectileExtinction(ProjectileInfo[j][0], ProjectileInfo[j][1]);
+                DecreaseHP();
+            }
+            else if (GameBoardInfo[ProjectileInfo[j][1]][ProjectileInfo[j][0]] == WALL || GameBoardInfo[ProjectileInfo[j][1]][ProjectileInfo[j][0]] == CHAINSAW) {
+                //벽일 경우 투사체 삭제
+                ProjectileExtinction(ProjectileInfo[j][0], ProjectileInfo[j][1]);
+            }
+            else {
+                //나머지의 경우 (투사체 저장만 하고 그리지 않기) = (넘기기)
+            }
+
+            break;
+        }
+    }
+}
+
+void ProjectileMove()   //적과 마주치면 지우고 projectile만 업그레이드, 적이 없으면 gameboardinfo 최신화 and 그리기, pc나 벽과 마주치면 projectile 소멸
+{
+    for (int i = 0; i < maxProjectile; i++) {
+        if (ProjectileInfo[i][0] == 0) continue; //예외 처리
+
+        if (GameBoardInfo[ProjectileInfo[i][1]][ProjectileInfo[i][0]] == NPCBULLET) {
+            SetCurrentCursorPos(ProjectileInfo[i][0] * 2 + GBOARD_ORIGIN_X, ProjectileInfo[i][1] + GBOARD_ORIGIN_Y);
+            printf("  ");
+            GameBoardInfo[ProjectileInfo[i][1]][ProjectileInfo[i][0]] = 0;
+        }
+
+        switch (ProjectileInfo[i][2])
+        {
+        default:
+            break;
+        case UP:
+            ProjectileInfo[i][1]--;
+            break;
+        case DOWN:
+            ProjectileInfo[i][1]++;
+            break;
+        case LEFT:
+            ProjectileInfo[i][0]--;
+            break;
+        case RIGHT:
+            ProjectileInfo[i][0]++;
+            break;
+        }
+
+        switch (GameBoardInfo[ProjectileInfo[i][1]][ProjectileInfo[i][0]])
+        {
+        default:
+            if (GameBoardInfo[ProjectileInfo[i][1]][ProjectileInfo[i][0]] > 100) {
+                //스킬 이펙트와 충돌
+                if (GameBoardInfo[ProjectileInfo[i][1]][ProjectileInfo[i][0]] < 300) {
+                    if (GameBoardInfo[ProjectileInfo[i][1]][ProjectileInfo[i][0]] < 400) {
+                        for (int k = 0; k <= skillTop; k++) {
+                            if (skillEffectInfo[k].X == ProjectileInfo[i][0] && skillEffectInfo[k].Y == ProjectileInfo[i][1]) {
+                                RemoveSkillEffect(k);
+                                break;
+                            }
+                        }
+                    }
+                }
+                ProjectileExtinction(ProjectileInfo[i][0], ProjectileInfo[i][1]);
+                continue;
+            }
+            else if (GameBoardInfo[ProjectileInfo[i][1]][ProjectileInfo[i][0]] == LIFE || GameBoardInfo[ProjectileInfo[i][1]][ProjectileInfo[i][0]] == BOMB) {
+                //아이템과 충돌 시 아이템과 투사체 모두 삭제 -> ProjectileExtinction 함수로 전부 수행함
+                ProjectileExtinction(ProjectileInfo[i][0], ProjectileInfo[i][1]);
+                continue;
+            }
+            break;
+
+        case WALL:
+            ProjectileExtinction(ProjectileInfo[i][0], ProjectileInfo[i][1]);
+            continue;
+            break;
+        case CHAINSAW:
+            ProjectileExtinction(ProjectileInfo[i][0], ProjectileInfo[i][1]);
+            continue;
+            break;
+        case PC:
+            DecreaseHP();
+            ProjectileExtinction(ProjectileInfo[i][0], ProjectileInfo[i][1]);
+            continue;
+            break;
+        case NPC:
+            continue;
+            break;
+        case MOVINGRANGENPC:
+            continue;
+            break;
+        case STOPPEDRANGENPC:
+            continue;
+            break;
+        }
+
+        GameBoardInfo[ProjectileInfo[i][1]][ProjectileInfo[i][0]] = NPCBULLET;
+        SetCurrentCursorPos(ProjectileInfo[i][0] * 2 + GBOARD_ORIGIN_X, ProjectileInfo[i][1] + GBOARD_ORIGIN_Y);
+        textcolor(darkRED);
+        switch (ProjectileInfo[i][2])
+        {
+        default:
+            break;
+        case UP:
+            printf("↑");
+            break;
+        case DOWN:
+            printf("↓");
+            break;
+        case LEFT:
+            printf("←");
+            break;
+        case RIGHT:
+            printf("→");
+            break;
+        }
+    }
+}
+
+void ProjectileExtinction(int x, int y) // 투사체 소멸
+{
+    for (int i = 0; i < maxProjectile; i++)
+    {
+        if (ProjectileInfo[i][0] == x && ProjectileInfo[i][1] == y)
+        {
+            if (GameBoardInfo[y][x] != 2 && GameBoardInfo[y][x] != WALL&&GameBoardInfo[y][x]!=CHAINSAW)
+            {
+                SetCurrentCursorPos(ProjectileInfo[i][0] * 2 + GBOARD_ORIGIN_X, ProjectileInfo[i][1] + GBOARD_ORIGIN_Y);
+                printf("  ");
+                GameBoardInfo[ProjectileInfo[i][1]][ProjectileInfo[i][0]] = 0;
+            }
+            ProjectileInfo[i][0] = 0;
+            ProjectileInfo[i][1] = 0;
+            ProjectileInfo[i][2] = 0;
+        }
+    }
+}
+
+void PcShiftNext(int x, int y) {
+    //예외 처리
+    if (x < 0 || x > GBOARD_WIDTH || y < 0 || y > GBOARD_HEIGHT) return; //게임판 내부를 벗어나면 이동하지 않기
+    
+    //충돌 처리
+    for (int ny = y; ny < y + 2; ny++) {
+        for (int nx = x; nx < x + 2; nx++) {
+            switch (GameBoardInfo[ny][nx])
+            {
+            default: //기타; PC, 이펙트 등
+                //아이템 사용
+                if (GameBoardInfo[ny][nx] == LIFE || GameBoardInfo[ny][nx] == BOMB) UseItem(GameBoardInfo[ny][nx]);
+                //스킬 그대로 두고 밑으로 이동
+                break;
+            case 0: //아무것도 없을 경우 밑으로 이동
+                break;
+            case WALL: //벽일 경우 함수 종료
+                return;
+                break;
+            case CHAINSAW:
+                DecreaseHP();
+                if (x < 20)
+                {
+                    if (y < 20)CHAINSAWindex = 0;
+                    else CHAINSAWindex = 3;
+                }
+                else if(x<40)
+                {
+                    if (y < 20)CHAINSAWindex = 1;
+                    else CHAINSAWindex = 4;
+                }
+                else
+                {
+                    if (y < 20)CHAINSAWindex = 2;
+                    else CHAINSAWindex = 5;
+                }
+                ChainsawTouched[CHAINSAWindex] = 4;
+                return;
+                break;
+            case NPC: //npc일 경우 NpcDie 실행하고 hp 감소하고 밑으로 이동
+                NpcDie(nx, ny);
+                DecreaseHP();
+                //아이템 사용
+                if (GameBoardInfo[ny][nx] == LIFE || GameBoardInfo[ny][nx] == BOMB) UseItem(GameBoardInfo[ny][nx]);
+                break;
+            case MOVINGRANGENPC: //npc와 동일
+                RangeNpcDie(nx, ny);
+                DecreaseHP();
+                //아이템 사용
+                if (GameBoardInfo[ny][nx] == LIFE || GameBoardInfo[ny][nx] == BOMB) UseItem(GameBoardInfo[ny][nx]);
+                break;
+            case STOPPEDRANGENPC: //npc와 동일
+                StopRangeNpcDie(nx, ny);
+                DecreaseHP();
+                //아이템 사용
+                if (GameBoardInfo[ny][nx] == LIFE || GameBoardInfo[ny][nx] == BOMB) UseItem(GameBoardInfo[ny][nx]);
+                break;
+            case NPCBULLET: //적 투사체일 경우 투사체 없애고 hp 감소하고 밑으로 이동
+                ProjectileExtinction(nx, ny);
+                DecreaseHP();
+                break;
+            case BossNum: //보스일 경우 pc hp 감소하고 종료
+                DecreaseHP();
+                return;
+                break;
+            case BossSkillEffect: //보스 스킬일 경우 스킬 없어지고 pc hp 감소하고 밑으로 이동
+                DecreaseHP();
+                break;
+            }
+        }
+    }
+
+    //pc 이동 구현
+    //현재 pc 지우기
+    erasePC();
+
+    //다음 pc 그리기
+    PCPoint[0] = x;
+    PCPoint[1] = y;
+    drawPC();
+}
+
+void PcShiftLeft() {
+    PcShiftNext(PCPoint[0] - 1, PCPoint[1]);
+}
+
+void PcShiftRight() {
+    PcShiftNext(PCPoint[0] + 1, PCPoint[1]);
+}
+
+void PcShiftUp() {
+    PcShiftNext(PCPoint[0], PCPoint[1] - 1);
+}
+
+void PcShiftDown() {
+    PcShiftNext(PCPoint[0], PCPoint[1] + 1);
+}
+
+//원거리 npc 공격방향 최신화
+void RangeNpcAttackDirectionUpdate() { 
+    int PCPointX;
+    int PCPointY;
+
+    for (int i = 0; i < maxmob; i++) {
+        if (StopRangeNpcInfo[i][0] != 0) {
+            PCPointX = PCPoint[0];
+            PCPointY = PCPoint[1];
+
+            if (PCPointX < StopRangeNpcInfo[i][0])PCPointX++;
+            if (PCPointY < StopRangeNpcInfo[i][0])PCPointY++;
+
+            if ((PCPointX - StopRangeNpcInfo[i][0]) * (PCPointX - StopRangeNpcInfo[i][0]) - (PCPointY - StopRangeNpcInfo[i][1]) * (PCPointY - StopRangeNpcInfo[i][1]) > 0) {
+                if (PCPointX > StopRangeNpcInfo[i][0]) StopRangeNpcInfo[i][2] = RIGHT;
+                else StopRangeNpcInfo[i][2] = LEFT;
+            }
+            else {
+                if (PCPointY < StopRangeNpcInfo[i][1]) StopRangeNpcInfo[i][2] = UP;
+                else StopRangeNpcInfo[i][2] = DOWN;
+            }
+        }
+    }
+}
+
+void AllDie()
+{ 
+    for (int i = 0; i < maxmob; i++) {
+        if (GameBoardInfo[NpcInfo[i][1]][NpcInfo[i][0]] == NPC) {
+            IncreaseScore();
+        }
+        NpcDie(NpcInfo[i][0], NpcInfo[i][1]);
+    }
+    for (int i = 0; i < maxmob; i++) {
+        if (GameBoardInfo[RangeNpcInfo[i][1]][RangeNpcInfo[i][0]] == MOVINGRANGENPC) {
+            IncreaseScore();
+        }
+        RangeNpcDie(RangeNpcInfo[i][0], RangeNpcInfo[i][1]);
+    }
+    for (int i = 0; i < maxmob; i++) {
+        if (GameBoardInfo[StopRangeNpcInfo[i][1]][StopRangeNpcInfo[i][0]] == STOPPEDRANGENPC) {
+            IncreaseScore();
+        }
+        StopRangeNpcDie(StopRangeNpcInfo[i][0], StopRangeNpcInfo[i][1]);
+    }
+    for (int i = 0; i < maxProjectile; i++) {
+        ProjectileExtinction(ProjectileInfo[i][0], ProjectileInfo[i][1]);
+    }
+}

--- a/PCNPC.h
+++ b/PCNPC.h
@@ -1,0 +1,52 @@
+#pragma once
+#define maxmob 15
+#define maxProjectile 90
+
+#define WALL 1
+#define PC 2
+#define NPC 3
+#define MOVINGRANGENPC 4
+#define STOPPEDRANGENPC 5
+#define NPCBULLET 9
+#define CHAINSAW 8
+
+#define RIGHT 100
+#define LEFT 200
+#define UP 300
+#define DOWN 400
+
+extern int NpcInfo[maxmob][2];
+extern int RangeNpcInfo[maxmob][2];
+extern int StopRangeNpcInfo[maxmob][3];
+extern int PCPoint[2];
+extern int ProjectileInfo[maxProjectile][3];
+
+
+extern int TimeCount;
+extern int TimeCount2;
+extern int AttackCount;
+extern int killCount;
+extern int item;
+extern int ChainsawTouched[6];
+extern COORD pc;
+
+COORD RandomSideXY();
+void NpcSpawn();
+void NpcMove();
+void RangeNpcSpawn();
+void RangeNpcMove();
+int DistanceSquare(int x1, int y1, int x2, int y2);
+void RangeNpcAttack();
+void ProjectileMove();
+void NpcDie(int Npc_X, int Npc_Y);
+void RangeNpcDie(int Npc_X, int Npc_Y);
+void StopRangeNpcDie(int Npc_X, int Npc_Y);
+void ProjectileExtinction(int x, int y);
+
+void PcShiftNext(int x, int y);
+void PcShiftLeft();
+void PcShiftDown();
+void PcShiftUp();
+void PcShiftRight();
+void RangeNpcAttackDirectionUpdate();
+void AllDie();

--- a/Skill.c
+++ b/Skill.c
@@ -1,0 +1,1357 @@
+#pragma warning(disable:4996)
+#include <stdio.h>
+#include <Windows.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <conio.h>
+#include <stdbool.h>
+//헤더 파일
+#include "DrawBoard.h"
+#include "Cursor.h"
+#include "Color.h"
+#include "Stage.h"
+#include "MainMenu.h"
+#include "ProcessKeyInput.h"
+#include "PCNPC.h"
+#include "Skill.h"
+
+skill skillList[SKILL_TYPE][SKILL_LEVEL]; //스킬 목록
+int selectedSkill[SELECT_SIZE]; //보유한 스킬 번호(110, 120, 130, 210, ...)
+skillEffect skillEffectInfo[GBOARD_HEIGHT * GBOARD_WIDTH]; //스킬 이펙트 좌표 저장 배열
+int skillTop = -1; //skillEffectInfo 최대 인덱스
+int flag;
+COORD old_cursor; //근접공격 이전 pc 위치
+int old_dir; //근접공격 이전 pc 방향
+
+void sub_AddEffectByDirection(COORD cursor, int type, int level, int x, int y, int nx, int ny, int dir) {
+	COORD arrCur;
+	//예외 처리 
+	if (skillList[type - 1][level - 1].effect[nx][ny] == 0) return; //스킬이펙트가 없을 경우 넘기기
+	if (cursor.X + x < GBOARD_ORIGIN_X - 1 || cursor.X + x > GBOARD_ORIGIN_X + GBOARD_WIDTH * 2 || cursor.Y + y < GBOARD_ORIGIN_Y || cursor.Y + y > GBOARD_ORIGIN_Y + GBOARD_HEIGHT) return; //커서가 게임판 내부를 벗어나면 넘기기
+
+	arrCur = ConvertCursorIntoArrCur(cursor);
+
+	//충돌 검사 및 이펙트 번호를 게임판 배열에 저장
+	if (type == 1 || type == 2 || type == 3) {
+		switch (GameBoardInfo[arrCur.Y + y][arrCur.X + x])
+		{
+		default:
+			//기타
+			//게임판 스킬 이펙트 좌표를 배열에 저장
+			skillTop++;
+			skillEffectInfo[skillTop].X = arrCur.X + x;
+			skillEffectInfo[skillTop].Y = arrCur.Y + y;
+			skillEffectInfo[skillTop].dir = dir;
+			skillEffectInfo[skillTop].level = level;
+			skillEffectInfo[skillTop].type = type;
+			skillEffectInfo[skillTop].ef = skillList[type - 1][level - 1].effect[nx][ny];
+			break;
+		case 0:
+			//비어있을 경우 이펙트 출력하고 게임판에 추가하고 스킬이펙트배열에 좌표 저장
+			//이펙트 출력
+			SetCurrentCursorPos(cursor.X + x * 2, cursor.Y + y);
+			drawSkillShape(type, level);
+			//게임판에 추가
+			GameBoardInfo[arrCur.Y + y][arrCur.X + x] = skillList[type - 1][level - 1].effect[nx][ny] + dir;
+			//게임판 스킬 이펙트 좌표를 배열에 저장
+			skillTop++;
+			skillEffectInfo[skillTop].X = arrCur.X + x;
+			skillEffectInfo[skillTop].Y = arrCur.Y + y;
+			skillEffectInfo[skillTop].dir = dir;
+			skillEffectInfo[skillTop].level = skillList[type - 1][level - 1].level;
+			skillEffectInfo[skillTop].type = skillList[type - 1][level - 1].type;
+			skillEffectInfo[skillTop].ef = skillList[type - 1][level - 1].effect[nx][ny];
+			break;
+		case WALL:
+			//벽이면 생성하지 않고 넘기기
+			break;
+		case CHAINSAW:
+			break;
+		case NPC:
+			//npc면 npcdie하고 넘기기
+			NpcDie(arrCur.X + x, arrCur.Y + y);
+			IncreaseScore();
+			if (type == 3) {
+				//이펙트 출력
+				SetCurrentCursorPos(cursor.X + x * 2, cursor.Y + y);
+				drawSkillShape(type, level);
+				//게임판에 추가
+				GameBoardInfo[arrCur.Y + y][arrCur.X + x] = skillList[type - 1][level - 1].effect[nx][ny] + dir;
+				//게임판 스킬 이펙트 좌표를 배열에 저장
+				skillTop++;
+				skillEffectInfo[skillTop].X = arrCur.X + x;
+				skillEffectInfo[skillTop].Y = arrCur.Y + y;
+				skillEffectInfo[skillTop].dir = dir;
+				skillEffectInfo[skillTop].level = skillList[type - 1][level - 1].level;
+				skillEffectInfo[skillTop].type = skillList[type - 1][level - 1].type;
+				skillEffectInfo[skillTop].ef = skillList[type - 1][level - 1].effect[nx][ny];
+			}
+			break;
+		case MOVINGRANGENPC:
+			//npc와 동일
+			RangeNpcDie(arrCur.X + x, arrCur.Y + y);
+			IncreaseScore();
+			if (type == 3) {
+				//이펙트 출력
+				SetCurrentCursorPos(cursor.X + x * 2, cursor.Y + y);
+				drawSkillShape(type, level);
+				//게임판에 추가
+				GameBoardInfo[arrCur.Y + y][arrCur.X + x] = skillList[type - 1][level - 1].effect[nx][ny] + dir;
+				//게임판 스킬 이펙트 좌표를 배열에 저장
+				skillTop++;
+				skillEffectInfo[skillTop].X = arrCur.X + x;
+				skillEffectInfo[skillTop].Y = arrCur.Y + y;
+				skillEffectInfo[skillTop].dir = dir;
+				skillEffectInfo[skillTop].level = skillList[type - 1][level - 1].level;
+				skillEffectInfo[skillTop].type = skillList[type - 1][level - 1].type;
+				skillEffectInfo[skillTop].ef = skillList[type - 1][level - 1].effect[nx][ny];
+			}
+			break;
+		case STOPPEDRANGENPC:
+			//npc와 동일
+			StopRangeNpcDie(arrCur.X + x, arrCur.Y + y);
+			IncreaseScore();
+			if (type == 3) {
+				//이펙트 출력
+				SetCurrentCursorPos(cursor.X + x * 2, cursor.Y + y);
+				drawSkillShape(type, level);
+				//게임판에 추가
+				GameBoardInfo[arrCur.Y + y][arrCur.X + x] = skillList[type - 1][level - 1].effect[nx][ny] + dir;
+				//게임판 스킬 이펙트 좌표를 배열에 저장
+				skillTop++;
+				skillEffectInfo[skillTop].X = arrCur.X + x;
+				skillEffectInfo[skillTop].Y = arrCur.Y + y;
+				skillEffectInfo[skillTop].dir = dir;
+				skillEffectInfo[skillTop].level = skillList[type - 1][level - 1].level;
+				skillEffectInfo[skillTop].type = skillList[type - 1][level - 1].type;
+				skillEffectInfo[skillTop].ef = skillList[type - 1][level - 1].effect[nx][ny];
+			}
+			break;
+		case NPCBULLET:
+			//npc와 동일
+			ProjectileExtinction(arrCur.X + x, arrCur.Y + y);
+			if (type == 3) {
+				//이펙트 출력
+				SetCurrentCursorPos(cursor.X + x * 2, cursor.Y + y);
+				drawSkillShape(type, level);
+				//게임판에 추가
+				GameBoardInfo[arrCur.Y + y][arrCur.X + x] = skillList[type - 1][level - 1].effect[nx][ny] + dir;
+				//게임판 스킬 이펙트 좌표를 배열에 저장
+				skillTop++;
+				skillEffectInfo[skillTop].X = arrCur.X + x;
+				skillEffectInfo[skillTop].Y = arrCur.Y + y;
+				skillEffectInfo[skillTop].dir = dir;
+				skillEffectInfo[skillTop].level = skillList[type - 1][level - 1].level;
+				skillEffectInfo[skillTop].type = skillList[type - 1][level - 1].type;
+				skillEffectInfo[skillTop].ef = skillList[type - 1][level - 1].effect[nx][ny];
+			}
+			break;
+		case BossNum:
+			//생성하지 않고 보스 hp 감소
+			DecreaseBossHP();
+			break;
+		}
+	}
+	//검
+	else if (type == 4) {
+		if (TimeCount % Diff.attackSpeed == Diff.attackSpeed / 2) {
+			//출력
+			switch (GameBoardInfo[arrCur.Y + y][arrCur.X + x])
+			{
+			default:
+				//기타
+				break;
+			case 0:
+				//비어있을 경우 이펙트 출력하고 게임판에 추가하고 스킬이펙트배열에 좌표 저장
+				//이펙트 출력
+				SetCurrentCursorPos(cursor.X + x * 2, cursor.Y + y);
+				drawSkillShape(type, level);
+				//게임판에 추가
+				GameBoardInfo[arrCur.Y + y][arrCur.X + x] = skillList[type - 1][level - 1].effect[nx][ny] + dir;
+				break;
+			case WALL:
+				//벽이면 생성하지 않고 넘기기
+				break;
+			case CHAINSAW:
+				break;
+			case NPC:
+				//npc면 npcdie하고 넘기기
+				NpcDie(arrCur.X + x, arrCur.Y + y);
+				IncreaseScore();
+				break;
+			case MOVINGRANGENPC:
+				//npc와 동일
+				RangeNpcDie(arrCur.X + x, arrCur.Y + y);
+				IncreaseScore();
+				break;
+			case STOPPEDRANGENPC:
+				//npc와 동일
+				StopRangeNpcDie(arrCur.X + x, arrCur.Y + y);
+				IncreaseScore();
+				break;
+			case NPCBULLET:
+				//npc와 동일
+				ProjectileExtinction(arrCur.X + x, arrCur.Y + y);
+				break;
+			case BossNum:
+				//이펙트 출력하지 않고 보스 hp 감소
+				DecreaseBossHP();
+				break;
+			case BossSkillEffect:
+				//이펙트 출력하지 않고 보스이펙트 제거
+				GameBoardInfo[arrCur.Y + y][arrCur.X + x] = 0;
+				break;
+			}
+
+			//이번 pc 좌표 및 방향 백업
+			old_cursor = cursor;
+			old_dir = dir;
+		}
+		else if (TimeCount % Diff.attackSpeed == Diff.attackSpeed / 2 + 1) {
+			//이전 이펙트 지우기
+			if (flag == 0) {
+				switch (old_dir)
+				{
+				case EAST:
+					for (int y = EFFECT_SIZE - 1; y >= 0; y--) {
+						for (int x = EFFECT_SIZE - 1; x >= 0; x--) {
+							erase_AddEffectByDirection(old_cursor, type, level, x, y, EFFECT_SIZE - 1 - y, EFFECT_SIZE - 1 - x, old_dir);
+						}
+					}
+					break;
+				case WEST:
+					for (int y = 0; y < EFFECT_SIZE; y++) {
+						for (int x = 0; x < EFFECT_SIZE; x++) {
+							erase_AddEffectByDirection(old_cursor, type, level, x, y, y, x, old_dir);
+						}
+					}
+					break;
+				case NORTH:
+					for (int y = 0; y < EFFECT_SIZE; y++) {
+						for (int x = EFFECT_SIZE - 1; x >= 0; x--) {
+							erase_AddEffectByDirection(old_cursor, type, level, x, y, EFFECT_SIZE - 1 - x, y, old_dir);
+						}
+					}
+					break;
+				case SOUTH:
+					for (int y = EFFECT_SIZE - 1; y >= 0; y--) {
+						for (int x = 0; x < EFFECT_SIZE; x++) {
+							erase_AddEffectByDirection(old_cursor, type, level, x, y, x, EFFECT_SIZE - 1 - y, old_dir);
+						}
+					}
+					break;
+				}
+				flag = 1;
+			}
+
+			//출력
+			switch (GameBoardInfo[arrCur.Y + y][arrCur.X + x])
+			{
+			default:
+				//기타
+				break;
+			case 0:
+				//비어있을 경우 이펙트 출력하고 게임판에 추가하고 스킬이펙트배열에 좌표 저장
+				//이펙트 출력
+				SetCurrentCursorPos(cursor.X + x * 2, cursor.Y + y);
+				drawSkillShape(type, level);
+				//게임판에 추가
+				GameBoardInfo[arrCur.Y + y][arrCur.X + x] = skillList[type - 1][level - 1].effect[nx][ny] + dir;
+				break;
+			case WALL:
+				//벽이면 생성하지 않고 넘기기
+				break;
+			case CHAINSAW:
+				break;
+			case NPC:
+				//npc면 npcdie하고 넘기기
+				NpcDie(arrCur.X + x, arrCur.Y + y);
+				IncreaseScore();
+				break;
+			case MOVINGRANGENPC:
+				//npc와 동일
+				RangeNpcDie(arrCur.X + x, arrCur.Y + y);
+				IncreaseScore();
+				break;
+			case STOPPEDRANGENPC:
+				//npc와 동일
+				StopRangeNpcDie(arrCur.X + x, arrCur.Y + y);
+				IncreaseScore();
+				break;
+			case NPCBULLET:
+				//npc와 동일
+				ProjectileExtinction(arrCur.X + x, arrCur.Y + y);
+				break;
+			case BossNum:
+				//이펙트 출력하지 않고 보스 hp 감소
+				DecreaseBossHP();
+				break;
+			case BossSkillEffect:
+				//이펙트 출력하지 않고 보스이펙트 제거
+				GameBoardInfo[arrCur.Y + y][arrCur.X + x] = 0;
+				break;
+			}
+
+			//이번 pc 좌표 및 방향 백업
+			old_cursor = cursor;
+			old_dir = dir;
+		}
+		else if (TimeCount % Diff.attackSpeed == Diff.attackSpeed / 2 + 2) {
+			//이전 이펙트 지우기
+			if (flag == 0) {
+				switch (old_dir)
+				{
+				case EAST:
+					for (int y = EFFECT_SIZE - 1; y >= 0; y--) {
+						for (int x = EFFECT_SIZE - 1; x >= 0; x--) {
+							erase_AddEffectByDirection(old_cursor, type, level, x, y, EFFECT_SIZE - 1 - y, EFFECT_SIZE - 1 - x, old_dir);
+						}
+					}
+					break;
+				case WEST:
+					for (int y = 0; y < EFFECT_SIZE; y++) {
+						for (int x = 0; x < EFFECT_SIZE; x++) {
+							erase_AddEffectByDirection(old_cursor, type, level, x, y, y, x, old_dir);
+						}
+					}
+					break;
+				case NORTH:
+					for (int y = 0; y < EFFECT_SIZE; y++) {
+						for (int x = EFFECT_SIZE - 1; x >= 0; x--) {
+							erase_AddEffectByDirection(old_cursor, type, level, x, y, EFFECT_SIZE - 1 - x, y, old_dir);
+						}
+					}
+					break;
+				case SOUTH:
+					for (int y = EFFECT_SIZE - 1; y >= 0; y--) {
+						for (int x = 0; x < EFFECT_SIZE; x++) {
+							erase_AddEffectByDirection(old_cursor, type, level, x, y, x, EFFECT_SIZE - 1 - y, old_dir);
+						}
+					}
+					break;
+				}
+				flag = 1;
+			}
+
+			//출력
+			switch (GameBoardInfo[arrCur.Y + y][arrCur.X + x])
+			{
+			default:
+				//기타
+				break;
+			case 0:
+				//비어있을 경우 이펙트 출력하고 게임판에 추가하고 스킬이펙트배열에 좌표 저장
+				//이펙트 출력
+				SetCurrentCursorPos(cursor.X + x * 2, cursor.Y + y);
+				drawSkillShape(type, level);
+				//게임판에 추가
+				GameBoardInfo[arrCur.Y + y][arrCur.X + x] = skillList[type - 1][level - 1].effect[nx][ny] + dir;
+				break;
+			case WALL:
+				//벽이면 생성하지 않고 넘기기
+				break;
+			case CHAINSAW:
+				break;
+			case NPC:
+				//npc면 npcdie하고 넘기기
+				NpcDie(arrCur.X + x, arrCur.Y + y);
+				IncreaseScore();
+				break;
+			case MOVINGRANGENPC:
+				//npc와 동일
+				RangeNpcDie(arrCur.X + x, arrCur.Y + y);
+				IncreaseScore();
+				break;
+			case STOPPEDRANGENPC:
+				//npc와 동일
+				StopRangeNpcDie(arrCur.X + x, arrCur.Y + y);
+				IncreaseScore();
+				break;
+			case NPCBULLET:
+				//npc와 동일
+				ProjectileExtinction(arrCur.X + x, arrCur.Y + y);
+				break;
+			case BossNum:
+				//이펙트 출력하지 않고 보스 hp 감소
+				DecreaseBossHP();
+				break;
+			case BossSkillEffect:
+				//이펙트 출력하지 않고 보스이펙트 제거
+				GameBoardInfo[arrCur.Y + y][arrCur.X + x] = 0;
+				break;
+			}
+
+			//이번 pc 좌표 및 방향 백업
+			old_cursor = cursor;
+			old_dir = dir;
+		}
+		else if (TimeCount % Diff.attackSpeed == Diff.attackSpeed / 2 + 3) {
+			//이전 이펙트 지우기
+			if (flag == 0) {
+				switch (old_dir)
+				{
+				case EAST:
+					for (int y = EFFECT_SIZE - 1; y >= 0; y--) {
+						for (int x = EFFECT_SIZE - 1; x >= 0; x--) {
+							erase_AddEffectByDirection(old_cursor, type, level, x, y, EFFECT_SIZE - 1 - y, EFFECT_SIZE - 1 - x, old_dir);
+						}
+					}
+					break;
+				case WEST:
+					for (int y = 0; y < EFFECT_SIZE; y++) {
+						for (int x = 0; x < EFFECT_SIZE; x++) {
+							erase_AddEffectByDirection(old_cursor, type, level, x, y, y, x, old_dir);
+						}
+					}
+					break;
+				case NORTH:
+					for (int y = 0; y < EFFECT_SIZE; y++) {
+						for (int x = EFFECT_SIZE - 1; x >= 0; x--) {
+							erase_AddEffectByDirection(old_cursor, type, level, x, y, EFFECT_SIZE - 1 - x, y, old_dir);
+						}
+					}
+					break;
+				case SOUTH:
+					for (int y = EFFECT_SIZE - 1; y >= 0; y--) {
+						for (int x = 0; x < EFFECT_SIZE; x++) {
+							erase_AddEffectByDirection(old_cursor, type, level, x, y, x, EFFECT_SIZE - 1 - y, old_dir);
+						}
+					}
+					break;
+				}
+				flag = 1;
+			}
+		}
+	}
+	//방벽
+	else if (type == 5) {
+		if (TimeCount % (Diff.attackSpeed * 2) == Diff.attackSpeed / 2) {
+			//출력
+			switch (GameBoardInfo[arrCur.Y + y][arrCur.X + x])
+			{
+			default:
+				//기타
+				break;
+			case 0:
+				//비어있을 경우 이펙트 출력하고 게임판에 추가하고 스킬이펙트배열에 좌표 저장
+				//이펙트 출력
+				SetCurrentCursorPos(cursor.X + x * 2, cursor.Y + y);
+				drawSkillShape(type, level);
+				//게임판에 추가
+				GameBoardInfo[arrCur.Y + y][arrCur.X + x] = skillList[type - 1][level - 1].effect[nx][ny] + dir;
+				break;
+			case WALL:
+				//벽이면 생성하지 않고 넘기기
+				break;
+			case CHAINSAW:
+				break;
+			case NPC:
+				//npc면 npcdie하고 넘기기
+				NpcDie(arrCur.X + x, arrCur.Y + y);
+				IncreaseScore();
+				break;
+			case MOVINGRANGENPC:
+				//npc와 동일
+				RangeNpcDie(arrCur.X + x, arrCur.Y + y);
+				IncreaseScore();
+				break;
+			case STOPPEDRANGENPC:
+				//npc와 동일
+				StopRangeNpcDie(arrCur.X + x, arrCur.Y + y);
+				IncreaseScore();
+				break;
+			case NPCBULLET:
+				//npc와 동일
+				ProjectileExtinction(arrCur.X + x, arrCur.Y + y);
+				break;
+			case BossNum:
+				//이펙트 출력하지 않고 보스 hp 감소
+				DecreaseBossHP();
+				break;
+			case BossSkillEffect:
+				//이펙트 출력하지 않고 보스이펙트 제거
+				GameBoardInfo[arrCur.Y + y][arrCur.X + x] = 0;
+				break;
+			}
+		}
+	}
+	//망치
+	else if (type == 6) {
+		if (TimeCount % Diff.attackSpeed == Diff.attackSpeed / 2) {
+			//출력
+			switch (GameBoardInfo[arrCur.Y + y][arrCur.X + x])
+			{
+			default:
+				//기타
+				break;
+			case 0:
+				//비어있을 경우 이펙트 출력하고 게임판에 추가하고 스킬이펙트배열에 좌표 저장
+				//이펙트 출력
+				SetCurrentCursorPos(cursor.X + x * 2, cursor.Y + y);
+				drawSkillShape(type, level);
+				//게임판에 추가
+				GameBoardInfo[arrCur.Y + y][arrCur.X + x] = skillList[type - 1][level - 1].effect[nx][ny] + dir;
+				break;
+			case WALL:
+				//벽이면 생성하지 않고 넘기기
+				break;
+			case CHAINSAW:
+				break;
+			case NPC:
+				//npc면 npcdie하고 넘기기
+				NpcDie(arrCur.X + x, arrCur.Y + y);
+				IncreaseScore();
+				break;
+			case MOVINGRANGENPC:
+				//npc와 동일
+				RangeNpcDie(arrCur.X + x, arrCur.Y + y);
+				IncreaseScore();
+				break;
+			case STOPPEDRANGENPC:
+				//npc와 동일
+				StopRangeNpcDie(arrCur.X + x, arrCur.Y + y);
+				IncreaseScore();
+				break;
+			case NPCBULLET:
+				//npc와 동일
+				ProjectileExtinction(arrCur.X + x, arrCur.Y + y);
+				break;
+			case BossNum:
+				//이펙트 출력하지 않고 보스 hp 감소
+				DecreaseBossHP();
+				break;
+			case BossSkillEffect:
+				//이펙트 출력하지 않고 보스이펙트 제거
+				GameBoardInfo[arrCur.Y + y][arrCur.X + x] = 0;
+				break;
+			}
+
+			//이번 pc 좌표 및 방향 백업
+			old_cursor = cursor;
+			old_dir = dir;
+		}
+		else if (TimeCount % Diff.attackSpeed == Diff.attackSpeed / 2 + 1) {
+			//이전 이펙트 지우기
+			if (flag == 0) {
+				switch (old_dir)
+				{
+				case EAST:
+					for (int y = EFFECT_SIZE - 1; y >= 0; y--) {
+						for (int x = EFFECT_SIZE - 1; x >= 0; x--) {
+							erase_AddEffectByDirection(old_cursor, type, level, x, y, EFFECT_SIZE - 1 - y, EFFECT_SIZE - 1 - x, old_dir);
+						}
+					}
+					break;
+				case WEST:
+					for (int y = 0; y < EFFECT_SIZE; y++) {
+						for (int x = 0; x < EFFECT_SIZE; x++) {
+							erase_AddEffectByDirection(old_cursor, type, level, x, y, y, x, old_dir);
+						}
+					}
+					break;
+				case NORTH:
+					for (int y = 0; y < EFFECT_SIZE; y++) {
+						for (int x = EFFECT_SIZE - 1; x >= 0; x--) {
+							erase_AddEffectByDirection(old_cursor, type, level, x, y, EFFECT_SIZE - 1 - x, y, old_dir);
+						}
+					}
+					break;
+				case SOUTH:
+					for (int y = EFFECT_SIZE - 1; y >= 0; y--) {
+						for (int x = 0; x < EFFECT_SIZE; x++) {
+							erase_AddEffectByDirection(old_cursor, type, level, x, y, x, EFFECT_SIZE - 1 - y, old_dir);
+						}
+					}
+					break;
+				}
+				flag = 1;
+			}
+		}
+	}
+}
+
+void erase_AddEffectByDirection(COORD cursor, int type, int level, int x, int y, int nx, int ny, int dir) {
+	//예외 처리
+	if (skillList[type - 1][level - 1].effect[nx][ny] == 0) return; //스킬이펙트가 없을 경우 넘기기
+	if (cursor.X + x < GBOARD_ORIGIN_X - 1 || cursor.X + x > GBOARD_ORIGIN_X + GBOARD_WIDTH * 2 || cursor.Y + y < GBOARD_ORIGIN_Y || cursor.Y + y > GBOARD_ORIGIN_Y + GBOARD_HEIGHT) return; //커서가 게임판 내부를 벗어나면 넘기기
+	
+	COORD arrCur = ConvertCursorIntoArrCur(cursor);
+
+	//이전 근접 이펙트 지우기
+	if (GameBoardInfo[arrCur.Y + y][arrCur.X + x] >= 400) {
+		GameBoardInfo[arrCur.Y + y][arrCur.X + x] = 0;
+		SetCurrentCursorPos(cursor.X + x * 2, cursor.Y + y);
+		printf("  ");
+	}
+}
+
+void AddEffectByDirection(int skillNum, int dir) {
+	if (skillNum == 0) return; //스킬이 없으면 리턴
+
+	COORD cursor;
+	int type = (skillNum / 100) % 10;
+	int level = (skillNum / 10) % 10;
+
+	if (type < 1 || type > 9 || level < 1 || level > 3) return; //예외 처리
+
+	pc.X = PCPoint[0];
+	pc.Y = PCPoint[1];
+
+	flag = 0;
+
+	//현재 이펙트 그리기
+	switch (dir)
+	{
+	default:
+		break;
+	case EAST:
+		cursor.X = GBOARD_ORIGIN_X + (pc.X + EFFECT_SIZE - 2) * 2;
+		cursor.Y = GBOARD_ORIGIN_Y + pc.Y - 1;
+		SetCurrentCursorPos(cursor.X, cursor.Y);
+		for (int y = EFFECT_SIZE - 1; y >= 0; y--) {
+			for (int x = EFFECT_SIZE - 1; x >= 0; x--) {
+				sub_AddEffectByDirection(cursor, type, level, x, y, EFFECT_SIZE - 1 - y, EFFECT_SIZE - 1 - x, dir);
+			}
+		}
+		break;
+	case WEST:
+		cursor.X = GBOARD_ORIGIN_X + (pc.X - EFFECT_SIZE) * 2;
+		cursor.Y = GBOARD_ORIGIN_Y + pc.Y - 1;
+		SetCurrentCursorPos(cursor.X, cursor.Y);
+		for (int y = 0; y < EFFECT_SIZE; y++) {
+			for (int x = 0; x < EFFECT_SIZE; x++) {
+				sub_AddEffectByDirection(cursor, type, level, x, y, y, x, dir);
+			}
+		}
+		break;
+	case NORTH:
+		cursor.X = GBOARD_ORIGIN_X + (pc.X - 1) * 2;
+		cursor.Y = GBOARD_ORIGIN_Y + pc.Y - 4;
+		SetCurrentCursorPos(cursor.X, cursor.Y);
+		for (int y = 0; y < EFFECT_SIZE; y++) {
+			for (int x = EFFECT_SIZE - 1; x >= 0; x--) {
+				sub_AddEffectByDirection(cursor, type, level, x, y, EFFECT_SIZE - 1 - x, y, dir);
+			}
+		}
+		break;
+	case SOUTH:
+		cursor.X = GBOARD_ORIGIN_X + (pc.X - 1) * 2;
+		cursor.Y = GBOARD_ORIGIN_Y + pc.Y + 2;
+		SetCurrentCursorPos(cursor.X, cursor.Y);
+		for (int y = EFFECT_SIZE - 1; y >= 0; y--) {
+			for (int x = 0; x < EFFECT_SIZE; x++) {
+				sub_AddEffectByDirection(cursor, type, level, x, y, x, EFFECT_SIZE - 1 - y, dir);
+			}
+		}
+		break;
+	}
+
+	//디버그
+	/*SetCurrentCursorPos(GBOARD_ORIGIN_X + GBOARD_WIDTH * 2 + 4, 25);
+	printf("출력%d", TimeCount);
+	for (int y = 0; y < 3; y++) {
+		for (int x = 0; x < 3; x++) {
+			SetCurrentCursorPos(GBOARD_ORIGIN_X + GBOARD_WIDTH * 2 + (x + 2) * 4, 26 + y);
+			printf("%03d,", skillList[type - 1][level - 1].effect[y][x]);
+		}
+	}*/
+}
+
+//skillEffectInfo[idx] 제거
+void RemoveSkillEffect(int idx) {
+	//예외 처리
+	if (idx == 0 && skillEffectInfo[idx].X == 0 && skillEffectInfo[idx].Y == 0) return;
+
+	if (GameBoardInfo[skillEffectInfo[idx].Y][skillEffectInfo[idx].X] > 100) {
+		//이펙트 지우기
+		SetCurrentCursorPos(GBOARD_ORIGIN_X + skillEffectInfo[idx].X * 2, GBOARD_ORIGIN_Y + skillEffectInfo[idx].Y);
+		printf("  ");
+		//게임판에서 삭제
+		GameBoardInfo[skillEffectInfo[idx].Y][skillEffectInfo[idx].X] = 0;
+	}
+
+	//스킬이펙트배열에서 삭제
+	skillEffectInfo[idx].X = 0, skillEffectInfo[idx].Y = 0;
+
+	int cnt = 0;
+	for (int i = 0; i <= skillTop; i++) {
+		while (i + cnt <= skillTop) {
+			if (skillEffectInfo[i + cnt].X == 0 && skillEffectInfo[i + cnt].Y == 0) {
+				//0 제거
+				cnt++;
+				skillTop--;
+			}
+			else break;
+		}
+		skillEffectInfo[i] = skillEffectInfo[i + cnt];
+	}
+
+	//flag 반환
+	if (cnt != 0) flag = 1;
+}
+
+//발사된 스킬 업데이트
+void SkillEffectMove() {
+	for (int i = 0; i <= skillTop; i++) {
+		//스킬 좌표 업데이트
+		flag = 0; //skillEffectInfo[i]를 삭제하면 flag=1
+		UpdateSkillEffect(i);
+		if (flag == 1) i--; //현재 이펙트를 삭제하고 배열을 한 칸 왼쪽으로 당겼으므로 현재 칸에 다음 이펙트가 있으므로 다음 이펙트에 접근하기 위해 i 감소
+
+		//스킬 이펙트 전체 새로 그리기
+		for (int i = 0; i <= skillTop; i++) {
+			if (GameBoardInfo[skillEffectInfo[i].Y][skillEffectInfo[i].X] == PC || GameBoardInfo[skillEffectInfo[i].Y][skillEffectInfo[i].X] == LIFE || GameBoardInfo[skillEffectInfo[i].Y][skillEffectInfo[i].X] == BOMB || GameBoardInfo[skillEffectInfo[i].Y][skillEffectInfo[i].X] / 100 == 5) continue;
+			
+			GameBoardInfo[skillEffectInfo[i].Y][skillEffectInfo[i].X] = skillEffectInfo[i].ef;
+			SetCurrentCursorPos(GBOARD_ORIGIN_X + skillEffectInfo[i].X * 2, GBOARD_ORIGIN_Y + skillEffectInfo[i].Y);
+			drawSkillShape(skillEffectInfo[i].type, skillEffectInfo[i].level);
+		}
+	}
+}
+
+//다음 스킬 이펙트 그리기
+void UpdateSkillEffect(int idx) {
+	int ef = GameBoardInfo[skillEffectInfo[idx].Y][skillEffectInfo[idx].X]; //스킬 번호
+	int type = skillEffectInfo[idx].type; //스킬 타입
+	int level = skillEffectInfo[idx].level; //스킬 레벨
+	int dir = skillEffectInfo[idx].dir; //스킬 방향
+	COORD next;
+	next.X = skillEffectInfo[idx].X, next.Y = skillEffectInfo[idx].Y;
+
+	if (type == 1 || type == 2 || type == 3) {
+		//스킬 배열 최신화
+		switch (dir)
+		{
+		case EAST:
+			next.X++;
+			break;
+		case WEST:
+			next.X--;
+			break;
+		case NORTH:
+			next.Y--;
+			break;
+		case SOUTH:
+			next.Y++;
+			break;
+		}
+
+		switch (GameBoardInfo[next.Y][next.X])
+		{
+		default: //기타; PC, 이펙트, 아이템 등
+		   //이펙트 지우기
+			if (GameBoardInfo[skillEffectInfo[idx].Y][skillEffectInfo[idx].X] != PC && GameBoardInfo[skillEffectInfo[idx].Y][skillEffectInfo[idx].X] != LIFE && GameBoardInfo[skillEffectInfo[idx].Y][skillEffectInfo[idx].X] != BOMB && GameBoardInfo[skillEffectInfo[idx].Y][skillEffectInfo[idx].X] / 100 != 5) {
+				GameBoardInfo[skillEffectInfo[idx].Y][skillEffectInfo[idx].X] = 0;
+				SetCurrentCursorPos(GBOARD_ORIGIN_X + skillEffectInfo[idx].X * 2, GBOARD_ORIGIN_Y + skillEffectInfo[idx].Y);
+				printf("  ");
+			}
+			//스킬 좌표만 이동 저장
+			skillEffectInfo[idx].X = next.X, skillEffectInfo[idx].Y = next.Y;
+			break;
+		case 0:
+			//이펙트 지우기
+			if (GameBoardInfo[skillEffectInfo[idx].Y][skillEffectInfo[idx].X] != PC && GameBoardInfo[skillEffectInfo[idx].Y][skillEffectInfo[idx].X] != LIFE && GameBoardInfo[skillEffectInfo[idx].Y][skillEffectInfo[idx].X] != BOMB && GameBoardInfo[skillEffectInfo[idx].Y][skillEffectInfo[idx].X] / 100 != 5) {
+				GameBoardInfo[skillEffectInfo[idx].Y][skillEffectInfo[idx].X] = 0;
+				SetCurrentCursorPos(GBOARD_ORIGIN_X + skillEffectInfo[idx].X * 2, GBOARD_ORIGIN_Y + skillEffectInfo[idx].Y);
+				printf("  ");
+			}
+			//아무것도 없을 때 게임판 이동 위치에 스킬 이름 저장, 배열에 좌표 저장, 스킬 그리기
+			skillEffectInfo[idx].X = next.X, skillEffectInfo[idx].Y = next.Y;
+			break;
+		case WALL: //벽이면 스킬 삭제
+			RemoveSkillEffect(idx);
+			break;
+		case CHAINSAW:
+			RemoveSkillEffect(idx);
+			break;
+		case NPC: //적이면 적 제거하고 스킬 삭제
+			NpcDie(next.X, next.Y);
+			if (type == 3) {
+				GameBoardInfo[skillEffectInfo[idx].Y][skillEffectInfo[idx].X] = 0;
+				SetCurrentCursorPos(GBOARD_ORIGIN_X + skillEffectInfo[idx].X * 2, GBOARD_ORIGIN_Y + skillEffectInfo[idx].Y);
+				printf("  ");
+				skillEffectInfo[idx].X = next.X, skillEffectInfo[idx].Y = next.Y;
+			}
+			else RemoveSkillEffect(idx);
+			IncreaseScore();
+			break;
+		case MOVINGRANGENPC: //적이면 적 제거하고 스킬 삭제
+			RangeNpcDie(next.X, next.Y);
+			if (type == 3) {
+				GameBoardInfo[skillEffectInfo[idx].Y][skillEffectInfo[idx].X] = 0;
+				SetCurrentCursorPos(GBOARD_ORIGIN_X + skillEffectInfo[idx].X * 2, GBOARD_ORIGIN_Y + skillEffectInfo[idx].Y);
+				printf("  ");
+				skillEffectInfo[idx].X = next.X, skillEffectInfo[idx].Y = next.Y;
+			}
+			else RemoveSkillEffect(idx);
+			IncreaseScore();
+			break;
+		case STOPPEDRANGENPC: //적이면 적 제거하고 스킬 삭제
+			StopRangeNpcDie(next.X, next.Y);
+			if (type == 3) {
+				GameBoardInfo[skillEffectInfo[idx].Y][skillEffectInfo[idx].X] = 0;
+				SetCurrentCursorPos(GBOARD_ORIGIN_X + skillEffectInfo[idx].X * 2, GBOARD_ORIGIN_Y + skillEffectInfo[idx].Y);
+				printf("  ");
+				skillEffectInfo[idx].X = next.X, skillEffectInfo[idx].Y = next.Y;
+			}
+			else RemoveSkillEffect(idx);
+			IncreaseScore();
+			break;
+		case NPCBULLET: //적이면 적 제거하고 스킬 삭제
+			ProjectileExtinction(next.X, next.Y);
+			if (type == 3) {
+				GameBoardInfo[skillEffectInfo[idx].Y][skillEffectInfo[idx].X] = 0;
+				SetCurrentCursorPos(GBOARD_ORIGIN_X + skillEffectInfo[idx].X * 2, GBOARD_ORIGIN_Y + skillEffectInfo[idx].Y);
+				printf("  ");
+				skillEffectInfo[idx].X = next.X, skillEffectInfo[idx].Y = next.Y;
+			}
+			else RemoveSkillEffect(idx);
+			break;
+		case BossNum: //보스면 pc 스킬 없어지고 보스 hp 감소
+			RemoveSkillEffect(idx);
+			DecreaseBossHP();
+			break;
+		case BossSkillEffect: //보스 스킬이면 보스 스킬 없어지고 pc 스킬 없어짐
+			GameBoardInfo[next.Y][next.X] = 0;
+			SetCurrentCursorPos(GBOARD_ORIGIN_X + next.X * 2, GBOARD_ORIGIN_Y + next.Y);
+			printf("  ");
+			RemoveSkillEffect(idx);
+			break;
+		}
+	}
+}
+
+//랜덤 스킬 3개 중 하나 선택
+void SelectNewSkill() {
+	int s[3], l[3];
+	int ran1, ran2, ran3;
+
+	flag = 0;
+
+	SetCurrentCursorPos(pos_skillSelect.X, pos_skillSelect.Y);
+	textcolor(YELLOW);
+	printf("★★★ 스킬 선택 ★★★");
+
+	//스킬 선택 UI 띄우기
+	if (selectedSkill[0] == 0 && selectedSkill[1] == 0 && selectedSkill[2] == 0) {
+		for (int i = 1; i <= 3; i++) {
+			SetCurrentCursorPos(pos_skillSelect.X, pos_skillSelect.Y + i);
+			textcolor(WHITE);
+			printf("%d) 원거리 : ", i);
+			textcolor(SKYBLUE);
+			printf("%s", skillList[i - 1][0].name);
+		}
+
+		//키 입력받아서 스킬 선택
+		while (flag == 0) {
+			if (_kbhit() != 0) {
+				key = _getch();
+				switch (key)
+				{
+				case ONE:
+					selectedSkill[0] = 110, flag = 1;
+					break;
+				case TWO:
+					selectedSkill[0] = 210, flag = 1;
+					break;
+				case THREE:
+					selectedSkill[0] = 310, flag = 1;
+					break;
+				}
+			}
+		}
+	}
+	else {
+		ran1 = rand() % 3 + 1;
+		ran2 = rand() % 3 + 4;
+		ran3 = rand() % 3 + 7;
+
+		if (selectedSkill[0] == 0) s[0] = ran1, l[0] = 1;
+		else s[0] = selectedSkill[0] / 100 % 10, l[0] = selectedSkill[0] / 10 % 10 + 1;
+		if (selectedSkill[1] == 0) s[1] = ran2, l[1] = 1;
+		else s[1] = selectedSkill[1] / 100 % 10, l[1] = selectedSkill[1] / 10 % 10 + 1;
+		if (selectedSkill[2] == 0) s[2] = ran3, l[2] = 1;
+		else s[2] = selectedSkill[2] / 100 % 10, l[2] = selectedSkill[2] / 10 % 10 + 1;
+
+		for (int i = 1; i <= 3; i++) {
+			SetCurrentCursorPos(pos_skillSelect.X, pos_skillSelect.Y + i);
+			switch (i)
+			{
+			case 1:
+				textcolor(GRAY);
+				printf("%d) 원거리 : ", i);
+				if (l[i - 1] <= 3) {
+					textcolor(SKYBLUE);
+					printf("%s", skillList[s[i - 1] - 1][l[i - 1] - 1].name);
+				}
+				else {
+					textcolor(darkGRAY);
+					printf("최고 레벨 도달");
+				}
+				break;
+			case 2:
+				textcolor(GRAY);
+				printf("%d) 근거리 : ", i);
+				if (l[i - 1] <= 3) {
+					textcolor(SKYBLUE);
+					printf("%s", skillList[s[i - 1] - 1][l[i - 1] - 1].name);
+				}
+				else {
+					textcolor(darkGRAY);
+					printf("최고 레벨 도달");
+				}
+				break;
+			case 3:
+				textcolor(GRAY);
+				printf("%d) 패시브 : ", i);
+				if (l[i - 1] <= 3) {
+					textcolor(SKYBLUE);
+					printf("%s", skillList[s[i - 1] - 1][l[i - 1] - 1].name);
+				}
+				else {
+					textcolor(darkGRAY);
+					printf("최고 레벨 도달");
+				}
+				break;
+			}
+		}
+		
+		//키 입력받아서 스킬 선택
+		while (flag == 0) {
+			if (_kbhit() != 0) {
+				key = _getch();
+				switch (key)
+				{
+				case ONE:
+					if (l[0] <= 3) selectedSkill[0] = s[0] * 100 + l[0] * 10, flag = 1;
+					break;
+				case TWO:
+					if (l[1] <= 3) selectedSkill[1] = s[1] * 100 + l[1] * 10, flag = 1;
+					break;
+				case THREE:
+					if (l[2] <= 3) {
+						selectedSkill[2] = s[2] * 100 + l[2] * 10, flag = 1;
+						switch (selectedSkill[2])
+						{
+						case 710:
+							maxHP++;
+							HP++;
+							drawHP();
+							break;
+						case 720:
+							maxHP += 2;
+							HP += 2;
+							drawHP();
+							break;
+						case 730:
+							maxHP += 3;
+							HP += 3;
+							drawHP();
+							break;
+						case 810:
+							Diff.attackSpeed -= 2;
+							SetCurrentCursorPos(0, 0);
+							printf("%d", Diff.attackSpeed);
+							break;
+						case 820:
+							Diff.attackSpeed -= 2;
+							SetCurrentCursorPos(0, 0);
+							printf("%d", Diff.attackSpeed);
+							break;
+						case 830:
+							Diff.attackSpeed -= 2;
+							SetCurrentCursorPos(0, 0);
+							printf("%d", Diff.attackSpeed);
+							break;
+						case 910:
+							Diff.itemRate += 5;
+							break;
+						case 920:
+							Diff.itemRate += 5;
+							break;
+						case 930:
+							Diff.itemRate += 10;
+							break;
+						}
+					}
+					break;
+				}
+			}
+		}
+	}
+
+	//스킬 선택 UI 지우기
+	for (int i = 0; i <= 3; i++) {
+		SetCurrentCursorPos(pos_skillSelect.X, pos_skillSelect.Y + i);
+		printf("                                  ");
+	}
+}
+
+//스킬 정의; 1~3: 원거리 / 4~6: 근거리 / 7~9: 패시브
+void defineSkill(int type) {
+	int ef = 0;
+	char effect[3];
+	int* p;
+
+	//type: 1~3=원거리, 4~6=근거리, 7~9=패시브
+	switch (type)
+	{
+	default:
+		break;
+	case 1: //권총
+		strcpy(effect, "⊙"); //스킬 이펙트 지정
+		for (int i = 1; i <= SKILL_LEVEL; i++) {
+			ef = type * 100 + i * 10; //스킬 이펙트 번호; 3자리 정수
+			skillList[type - 1][i - 1].type = type;
+			skillList[type - 1][i - 1].level = i;
+
+			switch (i)
+			{
+			case 1:
+				strcpy(skillList[type - 1][i - 1].name, "권총");
+				strcpy(skillList[type - 1][i - 1].e, effect);
+				p = skillList[type - 1][i - 1].effect[0];
+				p[0] = 0, p[1] = 0, p[2] = 0, p[3] = 0;
+				p = skillList[type - 1][i - 1].effect[1];
+				p[0] = 0, p[1] = 0, p[2] = 0, p[3] = ef;
+				p = skillList[type - 1][i - 1].effect[2];
+				p[0] = 0, p[1] = 0, p[2] = 0, p[3] = 0;
+				p = skillList[type - 1][i - 1].effect[3];
+				p[0] = 0, p[1] = 0, p[2] = 0, p[3] = 0;
+				break;
+			case 2:
+				strcpy(skillList[type - 1][i - 1].name, "자동권총");
+				strcpy(skillList[type - 1][i - 1].e, effect);
+				p = skillList[type - 1][i - 1].effect[0];
+				p[0] = 0, p[1] = 0, p[2] = 0, p[3] = 0;
+				p = skillList[type - 1][i - 1].effect[1];
+				p[0] = 0, p[1] = ef, p[2] = ef, p[3] = ef;
+				p = skillList[type - 1][i - 1].effect[2];
+				p[0] = 0, p[1] = 0, p[2] = 0, p[3] = 0;
+				p = skillList[type - 1][i - 1].effect[3];
+				p[0] = 0, p[1] = 0, p[2] = 0, p[3] = 0;
+				break;
+			case 3:
+				strcpy(skillList[type - 1][i - 1].name, "기관총");
+				strcpy(skillList[type - 1][i - 1].e, effect);
+				p = skillList[type - 1][i - 1].effect[0];
+				p[0] = 0, p[1] = 0, p[2] = 0, p[3] = 0;
+				p = skillList[type - 1][i - 1].effect[1];
+				p[0] = ef, p[1] = ef, p[2] = ef, p[3] = ef;
+				p = skillList[type - 1][i - 1].effect[2];
+				p[0] = ef, p[1] = ef, p[2] = ef, p[3] = ef;
+				p = skillList[type - 1][i - 1].effect[3];
+				p[0] = 0, p[1] = 0, p[2] = 0, p[3] = 0;
+				break;
+			}
+		}
+		break;
+	case 2: //산탄총
+		strcpy(effect, "∴"); //스킬 이펙트 지정
+		for (int i = 1; i <= SKILL_LEVEL; i++) {
+			ef = type * 100 + i * 10; //스킬 이펙트 번호; 3자리 정수
+			skillList[type - 1][i - 1].type = type;
+			skillList[type - 1][i - 1].level = i;
+
+			switch (i)
+			{
+			case 1:
+				strcpy(skillList[type - 1][i - 1].name, "레버액션 산탄총");
+				strcpy(skillList[type - 1][i - 1].e, effect);
+				p = skillList[type - 1][i - 1].effect[0];
+				p[0] = 0, p[1] = 0, p[2] = 0, p[3] = 0;
+				p = skillList[type - 1][i - 1].effect[1];
+				p[0] = 0, p[1] = 0, p[2] = 0, p[3] = ef;
+				p = skillList[type - 1][i - 1].effect[2];
+				p[0] = 0, p[1] = 0, p[2] = 0, p[3] = ef;
+				p = skillList[type - 1][i - 1].effect[3];
+				p[0] = 0, p[1] = 0, p[2] = 0, p[3] = 0;
+				break;
+			case 2:
+				strcpy(skillList[type - 1][i - 1].name, "더블배럴 산탄총");
+				strcpy(skillList[type - 1][i - 1].e, effect);
+				p = skillList[type - 1][i - 1].effect[0];
+				p[0] = 0, p[1] = 0, p[2] = 0, p[3] = ef;
+				p = skillList[type - 1][i - 1].effect[1];
+				p[0] = 0, p[1] = 0, p[2] = 0, p[3] = ef;
+				p = skillList[type - 1][i - 1].effect[2];
+				p[0] = 0, p[1] = 0, p[2] = 0, p[3] = ef;
+				p = skillList[type - 1][i - 1].effect[3];
+				p[0] = 0, p[1] = 0, p[2] = 0, p[3] = ef;
+				break;
+			case 3:
+				strcpy(skillList[type - 1][i - 1].name, "펌프액션 산탄총");
+				strcpy(skillList[type - 1][i - 1].e, effect);
+				p = skillList[type - 1][i - 1].effect[0];
+				p[0] = 0, p[1] = 0, p[2] = ef, p[3] = ef;
+				p = skillList[type - 1][i - 1].effect[1];
+				p[0] = 0, p[1] = 0, p[2] = ef, p[3] = ef;
+				p = skillList[type - 1][i - 1].effect[2];
+				p[0] = 0, p[1] = 0, p[2] = ef, p[3] = ef;
+				p = skillList[type - 1][i - 1].effect[3];
+				p[0] = 0, p[1] = 0, p[2] = ef, p[3] = ef;
+				break;
+			}
+		}
+		break;
+	case 3: //활
+		strcpy(effect, "□"); //스킬 이펙트 지정
+		for (int i = 1; i <= SKILL_LEVEL; i++) {
+			ef = type * 100 + i * 10; //스킬 이펙트 번호; 3자리 정수
+			skillList[type - 1][i - 1].type = type;
+			skillList[type - 1][i - 1].level = i;
+
+			switch (i)
+			{
+			case 1:
+				strcpy(skillList[type - 1][i - 1].name, "단궁");
+				strcpy(skillList[type - 1][i - 1].e, effect);
+				p = skillList[type - 1][i - 1].effect[0];
+				p[0] = 0, p[1] = 0, p[2] = 0, p[3] = 0;
+				p = skillList[type - 1][i - 1].effect[1];
+				p[0] = 0, p[1] = 0, p[2] = ef, p[3] = ef;
+				p = skillList[type - 1][i - 1].effect[2];
+				p[0] = 0, p[1] = 0, p[2] = 0, p[3] = 0;
+				p = skillList[type - 1][i - 1].effect[3];
+				p[0] = 0, p[1] = 0, p[2] = 0, p[3] = 0;
+				break;
+			case 2:
+				strcpy(skillList[type - 1][i - 1].name, "장궁");
+				strcpy(skillList[type - 1][i - 1].e, effect);
+				p = skillList[type - 1][i - 1].effect[0];
+				p[0] = 0, p[1] = 0, p[2] = 0, p[3] = 0;
+				p = skillList[type - 1][i - 1].effect[1];
+				p[0] = ef, p[1] = ef, p[2] = ef, p[3] = ef;
+				p = skillList[type - 1][i - 1].effect[2];
+				p[0] = 0, p[1] = 0, p[2] = 0, p[3] = 0;
+				p = skillList[type - 1][i - 1].effect[3];
+				p[0] = 0, p[1] = 0, p[2] = 0, p[3] = 0;
+				break;
+			case 3:
+				strcpy(skillList[type - 1][i - 1].name, "대궁");
+				strcpy(skillList[type - 1][i - 1].e, effect);
+				p = skillList[type - 1][i - 1].effect[0];
+				p[0] = 0, p[1] = ef, p[2] = 0, p[3] = 0;
+				p = skillList[type - 1][i - 1].effect[1];
+				p[0] = ef, p[1] = ef, p[2] = ef, p[3] = ef;
+				p = skillList[type - 1][i - 1].effect[2];
+				p[0] = 0, p[1] = ef, p[2] = 0, p[3] = 0;
+				p = skillList[type - 1][i - 1].effect[3];
+				p[0] = 0, p[1] = 0, p[2] = 0, p[3] = 0;
+				break;
+			}
+		}
+		break;
+	case 4: //검
+		strcpy(effect, "◈"); //스킬 이펙트 지정
+		for (int i = 1; i <= SKILL_LEVEL; i++) {
+			ef = type * 100 + i * 10; //스킬 이펙트 번호; 3자리 정수
+			skillList[type - 1][i - 1].type = type;
+			skillList[type - 1][i - 1].level = i;
+
+			switch (i)
+			{
+			case 1:
+				strcpy(skillList[type - 1][i - 1].name, "단검");
+				strcpy(skillList[type - 1][i - 1].e, effect);
+				p = skillList[type - 1][i - 1].effect[0];
+				p[0] = 0, p[1] = 0, p[2] = 0, p[3] = 0;
+				p = skillList[type - 1][i - 1].effect[1];
+				p[0] = 0, p[1] = 0, p[2] = ef, p[3] = ef;
+				p = skillList[type - 1][i - 1].effect[2];
+				p[0] = 0, p[1] = 0, p[2] = 0, p[3] = 0;
+				p = skillList[type - 1][i - 1].effect[3];
+				p[0] = 0, p[1] = 0, p[2] = 0, p[3] = 0;
+				break;
+			case 2:
+				strcpy(skillList[type - 1][i - 1].name, "장검");
+				strcpy(skillList[type - 1][i - 1].e, effect);
+				p = skillList[type - 1][i - 1].effect[0];
+				p[0] = 0, p[1] = 0, p[2] = 0, p[3] = 0;
+				p = skillList[type - 1][i - 1].effect[1];
+				p[0] = ef, p[1] = ef, p[2] = ef, p[3] = ef;
+				p = skillList[type - 1][i - 1].effect[2];
+				p[0] = 0, p[1] = 0, p[2] = 0, p[3] = 0;
+				p = skillList[type - 1][i - 1].effect[3];
+				p[0] = 0, p[1] = 0, p[2] = 0, p[3] = 0;
+				break;
+			case 3:
+				strcpy(skillList[type - 1][i - 1].name, "대검");
+				strcpy(skillList[type - 1][i - 1].e, effect);
+				p = skillList[type - 1][i - 1].effect[0];
+				p[0] = 0, p[1] = 0, p[2] = 0, p[3] = 0;
+				p = skillList[type - 1][i - 1].effect[1];
+				p[0] = ef, p[1] = ef, p[2] = ef, p[3] = ef;
+				p = skillList[type - 1][i - 1].effect[2];
+				p[0] = ef, p[1] = ef, p[2] = ef, p[3] = ef;
+				p = skillList[type - 1][i - 1].effect[3];
+				p[0] = 0, p[1] = 0, p[2] = 0, p[3] = 0;
+				break;
+			}
+		}
+		break;
+	case 5: //방벽
+		strcpy(effect, "▣"); //스킬 이펙트 지정
+		for (int i = 1; i <= SKILL_LEVEL; i++) {
+			ef = type * 100 + i * 10; //스킬 이펙트 번호; 3자리 정수
+			skillList[type - 1][i - 1].type = type;
+			skillList[type - 1][i - 1].level = i;
+
+			switch (i)
+			{
+			case 1:
+				strcpy(skillList[type - 1][i - 1].name, "소형 방벽");
+				strcpy(skillList[type - 1][i - 1].e, effect);
+				p = skillList[type - 1][i - 1].effect[0];
+				p[0] = 0, p[1] = 0, p[2] = 0, p[3] = 0;
+				p = skillList[type - 1][i - 1].effect[1];
+				p[0] = 0, p[1] = 0, p[2] = 0, p[3] = ef;
+				p = skillList[type - 1][i - 1].effect[2];
+				p[0] = 0, p[1] = 0, p[2] = 0, p[3] = ef;
+				p = skillList[type - 1][i - 1].effect[3];
+				p[0] = 0, p[1] = 0, p[2] = 0, p[3] = 0;
+				break;
+			case 2:
+				strcpy(skillList[type - 1][i - 1].name, "중형 방벽");
+				strcpy(skillList[type - 1][i - 1].e, effect);
+				p = skillList[type - 1][i - 1].effect[0];
+				p[0] = 0, p[1] = 0, p[2] = 0, p[3] = ef;
+				p = skillList[type - 1][i - 1].effect[1];
+				p[0] = 0, p[1] = 0, p[2] = 0, p[3] = ef;
+				p = skillList[type - 1][i - 1].effect[2];
+				p[0] = 0, p[1] = 0, p[2] = 0, p[3] = ef;
+				p = skillList[type - 1][i - 1].effect[3];
+				p[0] = 0, p[1] = 0, p[2] = 0, p[3] = ef;
+				break;
+			case 3: //ㄷ자로 pc를 감싸는 형태
+				strcpy(skillList[type - 1][i - 1].name, "대형 방벽");
+				strcpy(skillList[type - 1][i - 1].e, effect);
+				p = skillList[type - 1][i - 1].effect[0];
+				p[0] = 0, p[1] = 0, p[2] = ef, p[3] = ef;
+				p = skillList[type - 1][i - 1].effect[1];
+				p[0] = 0, p[1] = 0, p[2] = ef, p[3] = ef;
+				p = skillList[type - 1][i - 1].effect[2];
+				p[0] = 0, p[1] = 0, p[2] = ef, p[3] = ef;
+				p = skillList[type - 1][i - 1].effect[3];
+				p[0] = 0, p[1] = 0, p[2] = ef, p[3] = ef;
+				break;
+			}
+		}
+		break;
+	case 6: //전투망치
+		strcpy(effect, "▨"); //스킬 이펙트 지정
+		for (int i = 1; i <= SKILL_LEVEL; i++) {
+			ef = type * 100 + i * 10; //스킬 이펙트 번호; 3자리 정수
+			skillList[type - 1][i - 1].type = type;
+			skillList[type - 1][i - 1].level = i;
+
+			switch (i)
+			{
+			case 1:
+				strcpy(skillList[type - 1][i - 1].name, "한손 전투망치");
+				strcpy(skillList[type - 1][i - 1].e, effect);
+				p = skillList[type - 1][i - 1].effect[0];
+				p[0] = 0, p[1] = 0, p[2] = 0, p[3] = 0;
+				p = skillList[type - 1][i - 1].effect[1];
+				p[0] = 0, p[1] = 0, p[2] = ef, p[3] = ef;
+				p = skillList[type - 1][i - 1].effect[2];
+				p[0] = 0, p[1] = 0, p[2] = ef, p[3] = ef;
+				p = skillList[type - 1][i - 1].effect[3];
+				p[0] = 0, p[1] = 0, p[2] = 0, p[3] = 0;
+				break;
+			case 2:
+				strcpy(skillList[type - 1][i - 1].name, "양손 전투망치");
+				strcpy(skillList[type - 1][i - 1].e, effect);
+				p = skillList[type - 1][i - 1].effect[0];
+				p[0] = 0, p[1] = ef, p[2] = ef, p[3] = ef;
+				p = skillList[type - 1][i - 1].effect[1];
+				p[0] = 0, p[1] = ef, p[2] = ef, p[3] = ef;
+				p = skillList[type - 1][i - 1].effect[2];
+				p[0] = 0, p[1] = ef, p[2] = ef, p[3] = ef;
+				p = skillList[type - 1][i - 1].effect[3];
+				p[0] = 0, p[1] = 0, p[2] = 0, p[3] = 0;
+				break;
+			case 3:
+				strcpy(skillList[type - 1][i - 1].name, "대형 전투망치");
+				strcpy(skillList[type - 1][i - 1].e, effect);
+				p = skillList[type - 1][i - 1].effect[0];
+				p[0] = ef, p[1] = ef, p[2] = ef, p[3] = ef;
+				p = skillList[type - 1][i - 1].effect[1];
+				p[0] = ef, p[1] = ef, p[2] = ef, p[3] = ef;
+				p = skillList[type - 1][i - 1].effect[2];
+				p[0] = ef, p[1] = ef, p[2] = ef, p[3] = ef;
+				p = skillList[type - 1][i - 1].effect[3];
+				p[0] = ef, p[1] = ef, p[2] = ef, p[3] = ef;
+				break;
+			}
+		}
+		break;
+	case 7: //최대 체력 증가
+		for (int i = 1; i <= SKILL_LEVEL; i++) {
+			skillList[type - 1][i - 1].type = type;
+			skillList[type - 1][i - 1].level = i;
+
+			switch (i)
+			{
+			case 1:
+				strcpy(skillList[type - 1][i - 1].name, "최대 체력 조금 증가");
+				//maxHP++;
+				break;
+			case 2:
+				strcpy(skillList[type - 1][i - 1].name, "최대 체력 보통 증가");
+				//maxHP++;
+				break;
+			case 3:
+				strcpy(skillList[type - 1][i - 1].name, "최대 체력 크게 증가");
+				//maxHP += 2;
+				break;
+			}
+		}
+		break;
+	case 8: //공격 속도 증가
+		for (int i = 1; i <= SKILL_LEVEL; i++) {
+			skillList[type - 1][i - 1].type = type;
+			skillList[type - 1][i - 1].level = i;
+
+			switch (i)
+			{
+			case 1:
+				strcpy(skillList[type - 1][i - 1].name, "공격 속도 조금 증가");
+				//Diff.attackSpeed--;
+				break;
+			case 2:
+				strcpy(skillList[type - 1][i - 1].name, "공격 속도 보통 증가");
+				//Diff.attackSpeed--;
+				break;
+			case 3:
+				strcpy(skillList[type - 1][i - 1].name, "공격 속도 크게 증가");
+				//Diff.attackSpeed -= 2;
+				break;
+			}
+		}
+		break;
+	case 9: //아이템 획득 확률 증가
+		for (int i = 1; i <= SKILL_LEVEL; i++) {
+			skillList[type - 1][i - 1].type = type;
+			skillList[type - 1][i - 1].level = i;
+
+			switch (i)
+			{
+			case 1:
+				strcpy(skillList[type - 1][i - 1].name, "아이템 확률 조금 증가");
+				//Diff.itemRate += 10;
+				break;
+			case 2:
+				strcpy(skillList[type - 1][i - 1].name, "아이템 확률 보통 증가");
+				//Diff.itemRate += 10;
+				break;
+			case 3:
+				strcpy(skillList[type - 1][i - 1].name, "아이템 확률 크게 증가");
+				//Diff.itemRate += 20;
+				break;
+			}
+		}
+		break;
+	}
+}

--- a/Skill.h
+++ b/Skill.h
@@ -1,0 +1,45 @@
+﻿#pragma once
+#define SKILL_LEVEL 3 //스킬 레벨 크기
+#define SKILL_TYPE 9 //스킬 종류 개수
+#define EFFECT_SIZE 4 //이펙트 배열 크기
+#define SKILL_LEN 16 //스킬 문자열 길이
+#define SELECT_SIZE 3 //스킬 선택 개수
+
+#define EAST 1 //방향: 오른쪽
+#define NORTH 2 //방향: 위쪽
+#define WEST 3 //방향: 왼쪽
+#define SOUTH 4 //방향: 아래쪽
+
+typedef struct skill {
+	char name[SKILL_LEN]; //스킬 이름
+	char e[3]; //스킬 이펙트 = 사용할 특수문자
+	//int effect[EFFECT_SIZE][EFFECT_SIZE]; //스킬 이펙트 배열
+	int effect[EFFECT_SIZE][EFFECT_SIZE];
+	int type;
+	int level;
+} skill;
+
+typedef struct skillEffect {
+	int X, Y;
+	int type;
+	int level;
+	int dir;
+	int ef;
+} skillEffect;
+
+extern skill skillList[SKILL_TYPE][SKILL_LEVEL];
+extern int selectedSkill[SELECT_SIZE];
+extern skillEffect skillEffectInfo[GBOARD_HEIGHT * GBOARD_WIDTH];
+extern int skillTop;
+extern int flag;
+extern COORD old_cursor;
+extern int old_dir;
+
+void sub_AddEffectByDirection(COORD cursor, int type, int level, int x, int y, int nx, int ny, int dir);
+void erase_AddEffectByDirection(COORD cursor, int type, int level, int x, int y, int nx, int ny, int dir);
+void AddEffectByDirection(int skillNum, int dir); //skillList[type-1][level-1]을 PC 방향 dir(EAST, NORTH, WEST, SOUTH)에 따라 추가
+void RemoveSkillEffect(int idx);
+void SkillEffectMove();
+void UpdateSkillEffect(int idx);
+void SelectNewSkill();
+void defineSkill(int type); //스킬1 정의; 기본 방향 = 왼쪽으로 발사 기준; 미완성


### PR DESCRIPTION
기본캐릭터 PC와 적몬스터 NPC를 구현하였습니다. NPC는 게임보드의 가장자리에서 랜덤으로 출현하고 원거리NPC와 근거리NPC 두가지를 구현하였습니다. 원거리NPC는 PC와의 일정거리가 도달하면 멈춰서  PC방향으로 화살을 쏘도록 설정하였습니다. 또한 적 NPC를 해치울수있는 PC의 스킬을 원거리공격 3개 근거리공격 3개를 구현하였고 각각 2번씩 업그레이드 버전이 있습니다.